### PR TITLE
Can not access git repository when "Subdirectory for HTTP access" is set

### DIFF
--- a/app/controllers/git_http_controller.rb
+++ b/app/controllers/git_http_controller.rb
@@ -20,9 +20,13 @@ class GitHttpController < ApplicationController
     return render_method_not_allowed if command == 'not_allowed'
     return render_not_found if !command
 
+    # strip HTTP prefix
+    @git_repo_path = @git_repo_path.sub(params[:prefix], '')
+
     logger.info "###### AUTHENTICATED ######"
     logger.info "project name   : #{@project.identifier}"
     logger.info "repository dir : #{@repository.url}"
+    logger.info "repository path: #{@git_repo_path}"
     logger.info "is_push        : #{@is_push}"
     if !@user.nil?
       logger.info "user_name      : #{@user.login}"


### PR DESCRIPTION
- app/controllers/git_http_controller.rb (GitHttpController#index): Strip
  "Subdirectory for HTTP access" prefix from repository path.
