### PR TITLE
Git do not ask for login/password

### DIFF
--- a/app/controllers/git_http_controller.rb
+++ b/app/controllers/git_http_controller.rb
@@ -41,7 +41,7 @@ class GitHttpController < ApplicationController
   def authenticate
     # fixme: rails3 route blobbing will not convert *other to array
     params[:path] = params[:path].split("/")
-    @is_push = (params[:path][0] == "git-receive-pack")
+    @is_push = (params[:path][0] == "git-receive-pack" || params[:service] == "git-receive-pack")
 
     query_valid = false
     authentication_valid = true


### PR DESCRIPTION
Git ask the user for a login/password only when it receive a 401 at the
first GET request.

If it gets a 401 at the POST, it just fails.
- app/controllers/git_http_controller.rb: Check for "service" parameter
  to detect "push".
