### PR TITLE
Always allow anonymous read of public repository over HTTP

### DIFF
--- a/app/controllers/git_http_controller.rb
+++ b/app/controllers/git_http_controller.rb
@@ -52,7 +52,7 @@ class GitHttpController < ApplicationController
     logger.info "############################"
 
     if (@repository = Repository.find_by_path(params[:repo_path],:parse_ext=>true)) && @repository.is_a?(Repository::Git)
-      if @project = @repository.project
+      if @project = @repository.project && @repository.extra[:git_http] != 0
         allow_anonymous_read = @project.is_public
         # Push requires HTTP enabled or valid SSL
         # Read is ok over HTTP for public projects


### PR DESCRIPTION
This fix my previous pull request where push was always enabled over `HTTP` as soon as the project was public.

Now, HTTP is ok for public project only for non push requests.

Regards.
