### PR TITLE
Unable to find gitolite version when PTY allocation is denied

### DIFF
--- a/lib/libs/git_hosting.rb
+++ b/lib/libs/git_hosting.rb
@@ -229,7 +229,7 @@ module GitHosting
 
 
   def self.gitolite_version
-    stdin, stdout, stderr = Open3.popen3("#{GitHosting.gitolite_ssh} #{GitHosting.git_user}@localhost")
+    stdin, stdout, stderr = Open3.popen3("#{GitHosting.gitolite_ssh} #{GitHosting.git_user}@localhost info")
 
     if !stderr.readlines.blank?
       return -1
@@ -249,7 +249,7 @@ module GitHosting
 
 
   def self.gitolite_version_output
-    stdin, stdout, stderr = Open3.popen3("#{GitHosting.gitolite_ssh} #{GitHosting.git_user}@localhost")
+    stdin, stdout, stderr = Open3.popen3("#{GitHosting.gitolite_ssh} #{GitHosting.git_user}@localhost info")
 
     errors = stderr.readlines
     if !errors.blank?


### PR DESCRIPTION
The defaut gitolite behaviour is to set authorized keys with "no-pty"
option.

Trying an SSH connection without a command execute a login shell which
output "Pseudo-terminal will not be allocated because stdin is not a
terminal" error message in addition to the result of the "info" command.
- lib/libs/git_hosting.rb (GitHosting.gitolite_version): run the "info"
  command explicitly.
- lib/libs/git_hosting.rb (GitHosting.gitolite_version_output): Ditoo.
