### PR TITLE
Fix gitolite version 2 detection. Version isn't necessarily preceded by a 'v'.

### DIFF
--- a/lib/libs/git_hosting.rb
+++ b/lib/libs/git_hosting.rb
@@ -236,7 +236,7 @@ module GitHosting
     else
       version = stdout.readlines
       version.each do |line|
-        if line.include?('gitolite v2.')
+        if line =~ /gitolite v?2\./
           return 2
         elsif line.include?('running gitolite3')
           return 3


### PR DESCRIPTION
Plugin could not detect gitolite version because the version is not always prefixed with a 'v'. My version of gitolite identifies itself as `gitolite 2.2-1 (Debian) running on git 1.7.9.5\n`
