### PR TITLE
Explicitly use SSLv3 for post-receive hook

### DIFF
--- a/contrib/hooks/post-receive.redmine_gitolite.rb
+++ b/contrib/hooks/post-receive.redmine_gitolite.rb
@@ -56,6 +56,7 @@ def run_query(url_str, params, with_https)
     http.read_timeout = 180
     if with_https
       http.use_ssl = true
+      http.ssl_version = :SSLv3
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
     req  = Net::HTTP::Post.new(url.request_uri)


### PR DESCRIPTION
I had the problem that mirrors where not automatically updated. After a lot of debugging of the post-receive hook I found the reason to be the following:

When Redmine runs on mod_passenger with apache2 with SSL on Debian 7 the post-receive hook fails. Apache2's mod_ssl configuration disables SSLv2 for security reasons. Ruby 1.9.3 still tries to connect using SSLv2 and fails to establish the connection. This PR changes the ssl version to SSLv3.
