### PR TITLE
gitolite_hooks_controller: fix undefined local variable

### DIFF
--- a/app/controllers/gitolite_hooks_controller.rb
+++ b/app/controllers/gitolite_hooks_controller.rb
@@ -289,7 +289,7 @@ class GitoliteHooksController < ApplicationController
       # Grab the repository path
       repo_path = GitHosting.repository_path(@repository)
       revisions_in_range = %x[#{GitHosting.git_cmd_runner} --git-dir='#{repo_path}' rev-list --reverse #{range}]
-      logger.info "Revisions in Range: #{revisions.split().join(' ')}"
+      logger.info "Revisions in Range: #{revisions_in_range.split().join(' ')}"
 
       commits = []
       revisions_in_range.split().each do |rev|


### PR DESCRIPTION
I had a Problem with the post-receive-urls, this commit fixed it.

Errormessage:

```
 NameError (undefined local variable or method `revisions' for #<GitoliteHooksController:0x0000000944eef0>):
  plugins/redmine_git_hosting/app/controllers/gitolite_hooks_controller.rb:292:in `block in post_receive_payloads'
  plugins/redmine_git_hosting/app/controllers/gitolite_hooks_controller.rb:270:in `each'
  plugins/redmine_git_hosting/app/controllers/gitolite_hooks_controller.rb:270:in `post_receive_payloads'
  plugins/redmine_git_hosting/app/controllers/gitolite_hooks_controller.rb:52:in `block in post_receive'
  actionpack (3.2.13) lib/action_dispatch/http/response.rb:44:in `each'
```
