### PR TITLE
Escaped the URLs and generated javascript in the url boxes

### DIFF
--- a/app/views/projects/_git_urls.html.erb
+++ b/app/views/projects/_git_urls.html.erb
@@ -23,7 +23,7 @@
         var urls = [];
 
       <% project.repository.available_urls.each do |key, value| %>
-        urls["git_url_<%= key %>"] = ["<%= j value[:url] %>", <%= j value[:commiter] %> ];
+        urls["git_url_<%= key %>"] = [encodeURI("<%= j value[:url] %>"), <%= j value[:commiter] %> ];
       <% end %>
 
         ZeroClipboard.setDefaults({ moviePath: "<%= GitHostingHelper.plugin_asset_link('ZeroClipboard.swf') %>" });

--- a/app/views/repositories/_git_urls.html.erb
+++ b/app/views/repositories/_git_urls.html.erb
@@ -23,7 +23,7 @@
       var urls = [];
 
     <% repository.available_urls.each do |key, value| -%>
-      urls["git_url_<%= key %>"] = ["<%= j value[:url] %>", <%= j value[:commiter] %> ];
+      urls["git_url_<%= key %>"] = [encodeURI("<%= j value[:url] %>"), <%= j value[:commiter] %> ];
     <% end %>
 
       ZeroClipboard.setDefaults({ moviePath: "<%= GitHostingHelper.plugin_asset_link('ZeroClipboard.swf') %>" });


### PR DESCRIPTION
The url boxes on the project page and on the repository page are not escaped properly.

There are two problems with the escaping.
- javascript is generated by the view for the ZeroClipboard library. This is not escaped. Someone could inject code in the page.
- the urls are not uri encoded. This can cause problems a part of the url has some odd characters in it. (example: spaces)

This PR fixes this.
