### PR TITLE
multimailhook swap sender_address and email_prefix

### DIFF
--- a/lib/redmine_gitolite/admin_repositories_helper.rb
+++ b/lib/redmine_gitolite/admin_repositories_helper.rb
@@ -118,8 +118,8 @@ module RedmineGitolite
           repo_conf.set_git_config("multimailhook.enabled", 'true')
           repo_conf.set_git_config("multimailhook.environment", "gitolite")
           repo_conf.set_git_config("multimailhook.mailinglist", mailing_list.keys.join(", "))
-          repo_conf.set_git_config("multimailhook.from", email_prefix)
-          repo_conf.set_git_config("multimailhook.emailPrefix", sender_address)
+          repo_conf.set_git_config("multimailhook.from", sender_address)
+          repo_conf.set_git_config("multimailhook.emailPrefix", email_prefix)
 
           # Set SMTP server for mail-notifications hook
           #~ repo_conf.set_git_config("multimailhook.smtpServer", ActionMailer::Base.smtp_settings[:address])


### PR DESCRIPTION
The sender_address and email_prefix variables are swapped in the admin_repositories_helper script. This causes emails with a email_prefix in the "from" line and a sender_address in the "subject" line.

Fix attached.
