### PR TITLE
redcarpet dependency has been added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'lockfile'
 gem 'jbox-gitolite', '~> 1.1.11'
 
 gem 'github-markup'
+gem 'redcarpet'
 gem 'RedCloth'
 gem 'org-ruby'
 gem 'creole'


### PR DESCRIPTION
This patch fixed the problem with markdown files. redcarpet has been added to Gemfile. See #144 
