### PR TITLE
gitolite_hooks_controller: fix access to deletet database column

### DIFF
--- a/app/controllers/gitolite_hooks_controller.rb
+++ b/app/controllers/gitolite_hooks_controller.rb
@@ -71,7 +71,7 @@ class GitoliteHooksController < ApplicationController
 
 
       ## Post to each post-receive URL
-      @repository.repository_post_receive_urls.active.order('created_at ASC').each do |post_receive_url|
+      @repository.repository_post_receive_urls.active.each do |post_receive_url|
         logger.info { "Notifying #{post_receive_url.url} ... " }
         y << "  - Notifying #{post_receive_url.url} ... "
 


### PR DESCRIPTION
The created_at column was deleted with the last db migration, without it the post receive hook was crashing
