### PR TITLE
Fix https:// notifications if TLSvX is mandatory

### DIFF
--- a/contrib/hooks/post-receive.redmine_gitolite.rb
+++ b/contrib/hooks/post-receive.redmine_gitolite.rb
@@ -83,7 +83,6 @@ def run_http_query(git_config)
 
   if url.scheme == 'https'
     http.use_ssl = true
-    http.ssl_version = :SSLv3 if http.respond_to?(:ssl_version)
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
   end
 


### PR DESCRIPTION
Nowadays servers tend to use TLSv1.[12] and SSLv3 will start to disappear
as only ie6 requires it…
In the post-receive hook SSLv3 is forced and notification fails
if server only accepts TLSv1.[12](eg: server gets 'A+' on https://www.ssllabs.com/ssltest/)

```
remote: Notifying Redmine about changes to this repository : 'project/repo' ...
remote: Redmine URL : 'https://myforge/githooks/post-receive/redmine/project'
remote: HTTP_ERROR : SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure
remote: Error contacting Redmine about changes to this repo.
```

This change let ruby's ssl stack negociate protocol with the server (works for me™ with a TLS-only server)
