### PR TITLE
change gem to access github with https:// protocol (port 443)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'lockfile'
-gem 'gitolite-rugged', :github => 'n-rodriguez/gitolite-rugged', :branch => 'devel'
+gem 'gitolite-rugged', :git => 'https://github.com/n-rodriguez/gitolite-rugged.git', :branch => 'devel'
 
 gem 'github-markup'
 gem 'redcarpet', '~> 2.3.0'


### PR DESCRIPTION
change gem to access github with use https:// protocol (port 443) not git:// protocol

git:// protocol used port 9418 and may be blocked by firewalls, but
https:// port 443 is almost always a good choice.

Ref: http://bundler.io/git.html
