### PR TITLE
Fix: Some (very old) repositories have been indentified as empty

### DIFF
--- a/lib/redmine_git_hosting/patches/repository_git_patch.rb
+++ b/lib/redmine_git_hosting/patches/repository_git_patch.rb
@@ -318,7 +318,7 @@ module RedmineGitHosting
 
 
         def empty?
-          if extra_info.nil? || !extra_info.has_key?('heads')
+          if extra_info.nil? || ( !extra_info.has_key?('heads') && !extra_info.has_key?('branches') )
             return true
           else
             return false


### PR DESCRIPTION
We have some rather old archived and/or closed repositories in our
redmine installation which definitely have content but have been
treated like empty repositories.

These old repos do not have a 'heads' key in the extra_info hash but
have a 'branches' key instead. Redmine switched from 'branches' to 'heads'
in revision 9283 and supports to upgrade from the old to the new format on the
next commit. However, supporting both keys means that I don't have to perform
dummy commits on inactive repos in order to make the repository viewer work
again.

Regards,
Mario
