### PR TITLE
fix: always show side bar but only show repositories list when more than one exists

### DIFF
--- a/app/views/repositories/_sidebar.html.erb
+++ b/app/views/repositories/_sidebar.html.erb
@@ -1,16 +1,13 @@
-<%= javascript_tag do %>
-  $(document).ready(function() {
-    $('#sidebar p').remove();
-  });
-<% end %>
-
-<ul class="repository git">
-  <% @repositories.sort.each do |repo| %>
+<% if @repositories.size > 1 %>
+  <h3><%= l(:label_repository_plural) %></h3>
+  <ul class="repository git">
+    <% @repositories.sort.each do |repo| %>
       <li class="repository git"><%= link_to h(repo.name), {:controller => 'repositories', :action => 'show', :id => @project, :repository_id => repo.identifier_param, :rev => nil, :path => nil},
                                     :class => [ 'repository', (repo == @repository ? 'selected' : ''), @repository.type.split('::')[1].downcase ].join(' ') %>
       </li>
-  <% end %>
-</ul>
+    <% end %>
+  </ul>
+<% end %>
 
 <% if @repository.is_a?(Repository::Git) && RedmineGitolite::Config.get_setting(:show_repositories_url) %>
   <div class="git_hosting_urls">

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -58,20 +58,8 @@
   <% end %>
 <% end %>
 
-<% if @repositories.size > 1 %>
-  <% content_for :sidebar do %>
-    <h3><%= l(:label_repository_plural) %></h3>
-    <p>
-      <%= @repositories.sort.collect {|repo|
-          link_to h(repo.name),
-                  {:controller => 'repositories', :action => 'show',
-                   :id => @project, :repository_id => repo.identifier_param, :rev => nil, :path => nil},
-                  :class => 'repository' + (repo == @repository ? ' selected' : '')
-        }.join('<br />').html_safe %>
-    </p>
-
-    <%= call_hook(:view_repositories_show_sidebar) %>
-  <% end %>
+<% content_for :sidebar do %>
+  <%= call_hook(:view_repositories_show_sidebar) %>
 <% end %>
 
 <% content_for :header_tags do %>


### PR DESCRIPTION
This should fix jbox-web/redmine_git_hosting#251

The code previously generated the repositories list two times (one in paragraphs and one in a list). The paragraph version was deleted afterward with javascript. Was this an artifact from the re-factoring or did I break something different by deleting the paragraph list?

Regards,
Mario
