### PR TITLE
Fix migration

### DIFF
--- a/db/migrate/20140618224954_add_fingerprint_to_gitolite_public_keys.rb
+++ b/db/migrate/20140618224954_add_fingerprint_to_gitolite_public_keys.rb
@@ -7,7 +7,7 @@ class AddFingerprintToGitolitePublicKeys < ActiveRecord::Migration
          key.reset_identifiers
        end
     end
-    change_column :gitolite_public_keys, :fingeprint, :string, :null => false
+    change_column :gitolite_public_keys, :fingerprint, :string, :null => false
   end
 
 


### PR DESCRIPTION
We're updating from older version, we have already created GitolitePublicKeys and this migration is ready only for new instalation of git_hosting plugin.
