### PR TITLE
Require authentication for accessing git repositories of public projects...

### DIFF
--- a/app/controllers/smart_http_controller.rb
+++ b/app/controllers/smart_http_controller.rb
@@ -31,7 +31,7 @@ class SmartHttpController < ApplicationController
       logger.info { "user_name       : #{@user.login}" }
       @authenticated = true
     else
-      if @project.is_public
+      if !Setting.login_required? && @project.is_public
         logger.info { "user_name       : anonymous (project is public)" }
         @authenticated = true
       else
@@ -78,7 +78,7 @@ class SmartHttpController < ApplicationController
     end
 
     @project = @repository.project
-    @allow_anonymous_read = @project.is_public
+    @allow_anonymous_read = !Setting.login_required? && @project.is_public
 
     logger.info { "project name    : #{@project.identifier}" }
     logger.info { "public project  : #{@allow_anonymous_read}" }


### PR DESCRIPTION
... if redmine is set to always require user authentication. Currently git repositories can be accessed (read-only) as long as the corresponding redmine project is public thus ignoring the redmine switch to alwawys requiring authentication.
