### PR TITLE
use value of :ssh_server_domain for plugin connections 

### DIFF
--- a/app/models/concerns/gitolitable/urls.rb
+++ b/app/models/concerns/gitolitable/urls.rb
@@ -23,7 +23,10 @@ module Gitolitable
 
 
     def ssh_url
-      "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}/#{git_access_path}"
+      if (RedmineGitHosting::Config.gitolite_server_port != '22')
+        then "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}:#{RedmineGitHosting::Config.gitolite_server_port}/#{git_access_path}"
+        else "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}/#{git_access_path}"
+      end
     end
 
 

--- a/lib/redmine_git_hosting/commands/gitolite.rb
+++ b/lib/redmine_git_hosting/commands/gitolite.rb
@@ -39,7 +39,7 @@ module RedmineGitHosting::Commands
 
 
       def gitolite_repository_count
-        sudo_capture('gitolite', 'list-phy-repos').split("\n").length
+        ssh_shell('gitolite', 'list-phy-repos').split("\n").length
       end
 
 

--- a/lib/redmine_git_hosting/config/gitolite_base.rb
+++ b/lib/redmine_git_hosting/config/gitolite_base.rb
@@ -92,7 +92,7 @@ module RedmineGitHosting::Config
 
 
       def gitolite_url
-        [gitolite_user, '@localhost'].join
+        [gitolite_user, '@', RedmineGitHosting::Config.ssh_server_domain].join
       end
 
 

--- a/lib/redmine_git_hosting/gitolite_wrapper.rb
+++ b/lib/redmine_git_hosting/gitolite_wrapper.rb
@@ -98,7 +98,7 @@ module RedmineGitHosting
         def gitolite_admin_settings
           {
             git_user:     RedmineGitHosting::Config.gitolite_user,
-            host:         "localhost:#{RedmineGitHosting::Config.gitolite_server_port}",
+            host:         "#{RedmineGitHosting::Config.ssh_server_domain}:#{RedmineGitHosting::Config.gitolite_server_port}",
             author_name:  RedmineGitHosting::Config.git_config_username,
             author_email: RedmineGitHosting::Config.git_config_email,
             public_key:   RedmineGitHosting::Config.gitolite_ssh_public_key,


### PR DESCRIPTION
Should fix issue #431
- it is now possible to use gitolite from an external server
- add ssh port display in repository-urls only if needed (Fancy).