### PR TITLE
In case of git command failure, log the actual command line

### DIFF
--- a/lib/redmine_git_hosting/shell_redirector.rb
+++ b/lib/redmine_git_hosting/shell_redirector.rb
@@ -48,8 +48,8 @@ module RedmineGitHosting
         end
 
         if status && status.exitstatus.to_i != 0
-          logger.error("Git exited with non-zero status : #{status.exitstatus}")
-          raise Redmine::Scm::Adapters::XitoliteAdapter::ScmCommandAborted, "Git exited with non-zero status : #{status.exitstatus}"
+          logger.error("Git exited with non-zero status : #{status.exitstatus} : #{cmd_str}")
+          raise Redmine::Scm::Adapters::XitoliteAdapter::ScmCommandAborted, "Git exited with non-zero status : #{status.exitstatus} : #{cmd_str}"
         end
 
         return retio


### PR DESCRIPTION
When some git action fails, it is useful to know what is the actual command that generated the failure.