### PR TITLE
BUGFIX: non-ASCII ReadMe error

### DIFF
--- a/lib/redmine_git_hosting/hooks/display_repository_readme.rb
+++ b/lib/redmine_git_hosting/hooks/display_repository_readme.rb
@@ -56,7 +56,7 @@ module RedmineGitHosting
 
 
         def get_formatter(repository, readme_file, rev)
-          raw_readme_text = repository.cat(readme_file.path, rev)
+          raw_readme_text = Redmine::CodesetUtil.to_utf8_by_setting(repository.cat(readme_file.path, rev))
 
           if MARKDOWN_EXT.include?(File.extname(readme_file.path))
             formatter_name = Redmine::WikiFormatting.format_names.find { |name| name =~ /markdown/i }


### PR DESCRIPTION
Avoid crash on ReadMe files containing non-ASCII symbols

Without such workaround this module constantly caused Server Error 500 in repository view with the following log dump, if the repo contained ReadMe file in UTF-8 codepage:

```
  Rendered plugins/redmine_git_hosting/app/views/repositories/show.html.erb within layouts/base (191.4ms)
Completed 500 Internal Server Error in 303ms (ActiveRecord: 30.8ms)                            

ActionView::Template::Error ("\xE2" from ASCII-8BIT to UTF-8):
    47:                        :id => @project, :page => nil, :key => User.current.rss_key})) %>
    48:    <% end %>
    49:
    50:    <%= call_hook(:view_repositories_show_bottom) %>
    51:
    52:    <% other_formats_links do |f| %>
    53:     <%= f.link_to 'Atom',
  lib/redmine/hook.rb:61:in `block (2 levels) in call_hook'
  lib/redmine/hook.rb:61:in `each'
  lib/redmine/hook.rb:61:in `block in call_hook'
  lib/redmine/hook.rb:58:in `tap'
  lib/redmine/hook.rb:58:in `call_hook'
  lib/redmine/hook.rb:158:in `call_hook'
  app/controllers/repositories_controller.rb:125:in `show'
```