### PR TITLE
Updates to github issues sync

### DIFF
--- a/app/services/redmine_hooks/github_issues_sync.rb
+++ b/app/services/redmine_hooks/github_issues_sync.rb
@@ -55,10 +55,10 @@ module RedmineHooks
         end
 
         if create_relation
-          github_issue = GithubIssue.new
-          github_issue.github_id = params[:issue][:id]
-          github_issue.issue_id = redmine_issue.id
-          github_issue.save!
+          new_github_issue = GithubIssue.new
+          new_github_issue.github_id = params[:issue][:id]
+          new_github_issue.issue_id = redmine_issue.id
+          new_github_issue.save!
         end
 
         if params.has_key?(:comment)

--- a/app/services/redmine_hooks/github_issues_sync.rb
+++ b/app/services/redmine_hooks/github_issues_sync.rb
@@ -87,9 +87,16 @@ module RedmineHooks
 
       def create_redmine_issue
         logger.info('Github Issues Sync : create new issue')
+        
+        tracker = project.trackers.find_by_name('GitHub')           
 
         issue             = project.issues.new
+         
+        if tracker.nil?
         issue.tracker_id  = project.trackers.first.try(:id)
+        else 
+          issue.tracker_id = tracker.id
+        end
         issue.subject     = params[:issue][:title].chomp[0, 255]
         issue.description = params[:issue][:body]
         issue.updated_on  = params[:issue][:updated_at]

--- a/app/services/redmine_hooks/github_issues_sync.rb
+++ b/app/services/redmine_hooks/github_issues_sync.rb
@@ -62,15 +62,24 @@ module RedmineHooks
         end
 
         if params.has_key?(:comment)
-          issue_journal = GithubComment.find_by_github_id(params[:comment][:id])
+           github_comment = GithubComment.find_by_github_id(params[:comment][:id])
 
-          if issue_journal.nil?
+          if  github_comment.nil?
             issue_journal = create_issue_journal(github_issue.issue)
 
             github_comment = GithubComment.new
             github_comment.github_id = params[:comment][:id]
             github_comment.journal_id = issue_journal.id
             github_comment.save!
+          else
+            issue_journal = Journal.find_by_id(github_comment.journal_id)
+            if issue_journal.nil?
+              issue_journal = create_issue_journal(github_issue.issue)
+              github_comment.journal_id = issue_journal.id
+            else
+              issue_journal.notes = params[:comment][:body]
+              issue_journal.save!
+            end
           end
         end
       end

--- a/app/services/redmine_hooks/github_issues_sync.rb
+++ b/app/services/redmine_hooks/github_issues_sync.rb
@@ -99,6 +99,9 @@ module RedmineHooks
         user = find_user(params[:issue][:user][:url])
         issue.author = user
 
+        object_custom_field_set_value(issue, 'github_user', params[:issue][:user][:html_url])
+        object_custom_field_set_value(issue, 'github_link', params[:issue][:html_url])
+
         issue.save!
         return issue
       end


### PR DESCRIPTION
A fix and some updates to the github issues sync:

i) fixed a bug which prevented github comments creating notes to the redmine issue
ii) modified the code, so that editing a github comment would update the related redmine issue note
iii) added a feature whereby if the custom field github_user exists it is populated with a url link to the github user (so that you can identify and contact the submitted if the redmine issue has been created by anonymous because the submitter is withholding their e-mail or does not have an account on the redmine instance)
iv) added a feature whereby if the custom field github_link exists it is populated with a url link to the original github issue
v) added a feature whereby if a tracker called "GitHub" exists the github issues are created in that tracker, otherwise revert to the previous behaviour of the first tracker in the project.

The patch requires the manual creation of the github_user, github_link custom fields (which should be of type link) and the GitHub tracker. The creation of these should probably be automated and added to the db/migrate scripts but I don't know enough about redmine plugins to do this.
