### PR TITLE
SSH keys with nil location can't be renamed

### DIFF
--- a/lib/tasks/rename_ssh_keys.rake
+++ b/lib/tasks/rename_ssh_keys.rake
@@ -12,7 +12,7 @@ namespace :redmine_git_hosting do
       repo_key['title']    = ssh_key.identifier
       repo_key['key']      = ssh_key.key
       repo_key['owner']    = ssh_key.owner
-      repo_key['location'] = ssh_key.location
+      repo_key['location'] = (ssh_key.location or "")
 
       puts "  - Delete SSH key #{ssh_key.identifier}"
       RedmineGitolite::GitHosting.resync_gitolite({ :command => :delete_ssh_key, :object => repo_key })


### PR DESCRIPTION
* lib/tasks/rename_ssh_keys.rake: Use empty string if location is nil.