### PR TITLE
added missing mandatory param for partial repositories/download_revision

### DIFF
--- a/app/views/archived_repositories/show.html.erb
+++ b/app/views/archived_repositories/show.html.erb
@@ -60,7 +60,8 @@
     <% end %>
   </ul>
 
-  <%= render :partial => 'repositories/download_revision' %>
+  <%= render :partial => 'repositories/download_revision'
+            :locals => { :repository => @repository } %>
 <% end %>
 
 <% content_for :header_tags do %>


### PR DESCRIPTION
Accessing "Archived repositorys" and trying to show specific repo leads to internal server error:
```
  Processing by ArchivedRepositoriesController#show as HTML
  Parameters: {"id"=>"loremipsum"}
  Current user: mkehl (id=6)
  Rendered plugins/redmine_git_hosting/app/views/common/_git_urls.html.haml (184.0ms)
  Rendered plugins/redmine_git_hosting/app/views/repositories/_show_top.html.haml (204.2ms)
  Rendered repositories/_navigation.html.erb (161.3ms)
  Rendered repositories/_breadcrumbs.html.erb (10.5ms)
  Rendered plugins/redmine_git_hosting/app/views/archived_repositories/_dir_list_content.html.erb (198.8ms)
  Rendered repositories/_dir_list.html.erb (207.9ms)
  Rendered repositories/_revision_graph.html.erb (17.0ms)
  Rendered plugins/redmine_git_hosting/app/views/archived_repositories/_revisions.html.erb (402.1ms)
  Rendered plugins/redmine_git_hosting/app/views/repositories/_download_revision.html.haml (605.5ms)
  Rendered plugins/redmine_git_hosting/app/views/archived_repositories/show.html.erb within layouts/base (2416.5ms)
Completed 500 Internal Server Error in 3842ms (ActiveRecord: 1059.9ms)

ActionView::Template::Error (undefined local variable or method `repository' for #<#<Class:0x007f5c24f03db8>:0x007f5c259941d8>):
    1: - if repository.downloadable?
    2:   - content_for :header_tags do
    3:     = bootstrap_load_module(:font_awesome)
    4: 
```
This means trying to render partial without mandatory param.
