### PR TITLE
Fix sudo error in hook installation (issue #642)

### DIFF
--- a/lib/redmine_git_hosting/commands/sudo.rb
+++ b/lib/redmine_git_hosting/commands/sudo.rb
@@ -139,7 +139,7 @@ module RedmineGitHosting
       #
       def sudo_capture(*params)
         cmd = sudo.concat(params)
-        capture(cmd)
+        capture(cmd).strip
       end
 
 


### PR DESCRIPTION
This fixed the sudo error in my installation, as a newline was being injected in the file path from somewhere.