### PR TITLE
Fixed installation of Gitolite3 hooks via moving .chomp into RedmineG…

### DIFF
--- a/lib/redmine_git_hosting/commands/gitolite.rb
+++ b/lib/redmine_git_hosting/commands/gitolite.rb
@@ -17,7 +17,7 @@ module RedmineGitHosting
 
       def sudo_gitolite_query_rc(param)
         begin
-          sudo_capture('gitolite', 'query-rc', param)
+          sudo_capture('gitolite', 'query-rc', param).try(:chomp)
         rescue RedmineGitHosting::Error::GitoliteCommandException => e
           logger.error("Can't retrieve Gitolite param : #{e.output}")
           nil

--- a/lib/redmine_git_hosting/config/gitolite_base.rb
+++ b/lib/redmine_git_hosting/config/gitolite_base.rb
@@ -29,12 +29,12 @@ module RedmineGitHosting
 
 
       def gitolite_bin_dir
-        @gitolite_bin_dir ||= RedmineGitHosting::Commands.sudo_gitolite_query_rc('GL_BINDIR').try(:chomp)
+        @gitolite_bin_dir ||= RedmineGitHosting::Commands.sudo_gitolite_query_rc('GL_BINDIR')
       end
 
 
       def gitolite_lib_dir
-        @gitolite_lib_dir ||= RedmineGitHosting::Commands.sudo_gitolite_query_rc('GL_LIBDIR').try(:chomp)
+        @gitolite_lib_dir ||= RedmineGitHosting::Commands.sudo_gitolite_query_rc('GL_LIBDIR')
       end
 
 


### PR DESCRIPTION
Fixed installation of Gitolite3 hooks via moving .chomp into RedmineGitHosting::Commands.sudo_gitolite_query_rc so that gitolite_local_code_dir also chomped

(it was generating path like this "/var/lib/git/local\n/hooks/common/post-receive")