### PR TITLE
Fix compatibility with Redmine 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'org-ruby'
 gem 'creole'
 # gem 'wikicloth'
 gem 'asciidoctor'
-gem 'rdoc'
+gem 'rdoc', "~> 4.3"
 
 # Rack parser for Hrack
 gem 'rack-parser', require: 'rack/parser'


### PR DESCRIPTION
This fixes the following error:

```
$ bundle install
Your Gemfile lists the gem redcarpet (~> 3.3.2) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.

[!] There was an error parsing `Gemfile`:
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice with different version requirements.
You specified: rdoc (~> 4.3) and rdoc (>= 0). Bundler cannot continue.

 #  from /srv/redmine/redmine-3.3/plugins/redmine_git_hosting/Gemfile:31
 #  -------------------------------------------
 #  gem 'asciidoctor'
 >  gem 'rdoc'
 #
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /srv/redmine/redmine-3.3/Gemfile:118
 #  -------------------------------------------
 #  Dir.glob File.expand_path("../plugins/*/{Gemfile,PluginGemfile}", __FILE__) do |file|
 >    eval_gemfile file
 #  end
 #  -------------------------------------------
```