### PR TITLE
Added .rstrip to remove line break after configuration property.

### DIFF
--- a/lib/redmine_git_hosting/config/gitolite_hooks.rb
+++ b/lib/redmine_git_hosting/config/gitolite_hooks.rb
@@ -29,7 +29,7 @@ module RedmineGitHosting
 
 
       def gitolite_local_code_dir
-        @gitolite_local_code_dir ||= RedmineGitHosting::Commands.sudo_gitolite_query_rc('LOCAL_CODE')
+        @gitolite_local_code_dir ||= RedmineGitHosting::Commands.sudo_gitolite_query_rc('LOCAL_CODE').rstrip
       end
 
 


### PR DESCRIPTION
Issue: #664

Appended '.rstrip' to the end of the line referenced in the referenced issue. If the blank characters are not removed, a line break will pass thru to other commands which will then try to copy a file to a path that contains a line break.