### PR TITLE
Force gitolite update when running update_repositories

### DIFF
--- a/lib/tasks/redmine_git_hosting.rake
+++ b/lib/tasks/redmine_git_hosting.rake
@@ -25,7 +25,7 @@ namespace :redmine_git_hosting do
   desc 'Update/repair Gitolite configuration'
   task update_repositories: [:environment] do
     RedmineGitHosting::ConsoleLogger.title('Performing manual update_repositories operation from command line') do
-      RedmineGitHosting::GitoliteAccessor.update_projects('all', { message: "Resync all projects (#{Project.all.length})..." })
+      RedmineGitHosting::GitoliteAccessor.update_projects('all', { message: "Resync all projects (#{Project.all.length})...", force: true })
     end
   end
 


### PR DESCRIPTION
While migrating to a new server I figured out, that running 
`RAILS_ENV=production rake redmine_git_hosting:update_repositories` does not update gitolite.conf while pushing the "Resync all projekts" button in the rescue-tab does.

In order to enable scriptable migrations I propose to add the `force: true` option to the
`redmine_git_hosting:update_repositories` task.