### PR TITLE
Implement restriction of repo URL depth within hierarchical organisat…

### DIFF
--- a/app/forms/plugin_settings_validation/redmine_config.rb
+++ b/app/forms/plugin_settings_validation/redmine_config.rb
@@ -9,7 +9,8 @@ module PluginSettingsValidation
                    :init_repositories_on_create,
                    :delete_git_repositories,
                    :download_revision_enabled,
-                   :gitolite_use_sidekiq
+                   :gitolite_use_sidekiq,
+                   :gitolite_one_level_repo_depth
 
       # This params work together!
       # When hierarchical_organisation = true, unique_repo_identifier MUST be false
@@ -23,6 +24,7 @@ module PluginSettingsValidation
           self.unique_repo_identifier = 'false'
         else
           self.unique_repo_identifier = 'true'
+          self.gitolite_one_level_repo_depth = 'false'
         end
 
         ## If we don't auto-create repository, we cannot create README file
@@ -37,6 +39,7 @@ module PluginSettingsValidation
       validates :gitolite_use_sidekiq,               presence: true, inclusion: { in: RedmineGitHosting::Validators::BOOLEAN_FIELDS }
       validates :hierarchical_organisation,          presence: true, inclusion: { in: RedmineGitHosting::Validators::BOOLEAN_FIELDS }
       validates :unique_repo_identifier,             presence: true, inclusion: { in: RedmineGitHosting::Validators::BOOLEAN_FIELDS }
+      validates :gitolite_one_level_repo_depth,      presence: true, inclusion: { in: RedmineGitHosting::Validators::BOOLEAN_FIELDS }
 
       validate :check_for_duplicated_repo
     end

--- a/app/models/concerns/gitolitable/paths.rb
+++ b/app/models/concerns/gitolitable/paths.rb
@@ -25,7 +25,10 @@ module Gitolitable
     # Call File.expand_path to add then remove heading /
     #
     def gitolite_repository_name
-      File.expand_path(File.join('./', RedmineGitHosting::Config.gitolite_redmine_storage_dir, get_full_parent_path, git_cache_id), '/')[1..-1]
+      repo_depth = RedmineGitHosting::Config.get_setting(:gitolite_one_level_repo_depth, true)
+      repo_path = File.expand_path(File.join('./', RedmineGitHosting::Config.gitolite_redmine_storage_dir, get_full_parent_path, git_cache_id), '/')[1..-1]
+
+      repo_depth ? repo_path.split("/").last(2).join("/") : repo_path
     end
 
 

--- a/app/models/concerns/gitolitable/paths.rb
+++ b/app/models/concerns/gitolitable/paths.rb
@@ -26,9 +26,35 @@ module Gitolitable
     #
     def gitolite_repository_name
       repo_depth = RedmineGitHosting::Config.get_setting(:gitolite_one_level_repo_depth, true)
-      repo_path = File.expand_path(File.join('./', RedmineGitHosting::Config.gitolite_redmine_storage_dir, get_full_parent_path, git_cache_id), '/')[1..-1]
+      redmine_storage = RedmineGitHosting::Config.get_setting(:gitolite_redmine_storage_dir, false)
+      repo_path = File.expand_path(File.join('./', redmine_storage, get_full_parent_path, git_cache_id), '/')[1..-1]
 
-      repo_depth ? repo_path.split("/").last(2).join("/") : repo_path
+      if repo_depth
+        if get_full_parent_path.blank?
+          # we are in parent project
+          new_repo = redmine_storage.blank? ? repo_path : repo_path.gsub(redmine_storage, "")[0..-1]
+          if new_repo.split("/").size == 2
+            redmine_storage.blank? ? new_repo : redmine_storage + new_repo
+          else
+            redmine_storage.blank? ? new_repo + "/" + new_repo : redmine_storage + new_repo + "/" + new_repo
+          end
+
+        else
+          # if parent path isnt blank, we are in subproject
+          new_repo = redmine_storage.blank? ? repo_path.gsub(get_full_parent_path, "")[1..-1] :
+            repo_path.gsub(redmine_storage + get_full_parent_path, "")[1..-1]
+          if new_repo.split("/").size == 2
+            redmine_storage.blank? ? new_repo : redmine_storage + new_repo
+          else
+            redmine_storage.blank? ? new_repo + "/" + new_repo : redmine_storage + new_repo + "/" + new_repo
+          end
+
+        end
+      else
+        # default Hierachical style
+        repo_path
+      end
+
     end
 
 

--- a/app/use_cases/settings/apply.rb
+++ b/app/use_cases/settings/apply.rb
@@ -83,6 +83,7 @@ module Settings
         ## Storage infos has changed, move repositories!
         if value_has_changed?(:gitolite_global_storage_dir)  ||
            value_has_changed?(:gitolite_redmine_storage_dir) ||
+           value_has_changed?(:gitolite_one_level_repo_depth)  ||
            value_has_changed?(:hierarchical_organisation)
 
           # Need to update everyone!

--- a/app/views/settings/redmine_git_hosting/_gitolite_display_access.html.haml
+++ b/app/views/settings/redmine_git_hosting/_gitolite_display_access.html.haml
@@ -1,12 +1,13 @@
 / Gitolite Display Access
-- gitolite_user                = RedmineGitHosting::Config.get_setting(:gitolite_user)
-- ssh_server_domain            = RedmineGitHosting::Config.get_setting(:ssh_server_domain)
-- gitolite_global_storage_dir  = RedmineGitHosting::Config.get_setting(:gitolite_global_storage_dir)
-- gitolite_redmine_storage_dir = RedmineGitHosting::Config.get_setting(:gitolite_redmine_storage_dir)
-- http_server_subdir           = RedmineGitHosting::Config.get_setting(:http_server_subdir)
-- http_server_domain           = RedmineGitHosting::Config.http_root_url
-- https_server_domain          = RedmineGitHosting::Config.https_root_url
-- hierarchical_organisation    = RedmineGitHosting::Config.get_setting(:hierarchical_organisation, true)
+- gitolite_user                 = RedmineGitHosting::Config.get_setting(:gitolite_user)
+- ssh_server_domain             = RedmineGitHosting::Config.get_setting(:ssh_server_domain)
+- gitolite_global_storage_dir   = RedmineGitHosting::Config.get_setting(:gitolite_global_storage_dir)
+- gitolite_redmine_storage_dir  = RedmineGitHosting::Config.get_setting(:gitolite_redmine_storage_dir)
+- http_server_subdir            = RedmineGitHosting::Config.get_setting(:http_server_subdir)
+- http_server_domain            = RedmineGitHosting::Config.http_root_url
+- https_server_domain           = RedmineGitHosting::Config.https_root_url
+- hierarchical_organisation     = RedmineGitHosting::Config.get_setting(:hierarchical_organisation, true)
+- gitolite_one_level_repo_depth = RedmineGitHosting::Config.get_setting(:gitolite_one_level_repo_depth, true)
 
 .git_hosting_access_box
 
@@ -21,50 +22,59 @@
   %span= raw l(:display_access_setup3)
 
   %p
+    - sample_def = "project3.git"
+    - sample_eg = "example.git"
+    - if hierarchical_organisation
+      - if gitolite_one_level_repo_depth
+        - sample_def = "project2/project3.git"
+        - sample_eg = "project2/example.git"
+      - else
+        - sample_def = "project1/project2/project3.git"
+        - sample_eg  = "project1/project2/project3/example.git"
     %label= l(:label_default_repository)
     %br
 
     %label= l(:label_storage_directory) + ' :'
-    = raw "~#{gitolite_user}/#{gitolite_global_storage_dir}#{gitolite_redmine_storage_dir}<em>#{hierarchical_organisation ? 'project1/project2/' : ''}project3.git</em>"
+    = raw "~#{gitolite_user}/#{gitolite_global_storage_dir}#{gitolite_redmine_storage_dir}<em>#{sample_def}</em>"
 
     %br
 
     %label= l(:label_ssh_access) + ' :'
     - gitSHP = ssh_server_domain.match(/:\d+$/)
-    = raw "#{gitSHP ? 'ssh://' : ''}#{gitolite_user}@#{ssh_server_domain}#{gitSHP ? '/' : ':'}#{gitolite_redmine_storage_dir}<em>#{hierarchical_organisation ? 'project1/project2/' : ''}project3.git</em>"
+    = raw "#{gitSHP ? 'ssh://' : ''}#{gitolite_user}@#{ssh_server_domain}#{gitSHP ? '/' : ':'}#{gitolite_redmine_storage_dir}<em>#{sample_def}</em>"
 
     %br
 
     %label= l(:label_http_access) + ' :'
-    = raw "http://<em>redmine-user</em>@#{http_server_domain}/#{http_server_subdir}<em>#{hierarchical_organisation ? 'project1/project2/' : ''}project3.git</em>"
+    = raw "http://<em>redmine-user</em>@#{http_server_domain}/#{http_server_subdir}<em>#{sample_def}</em>"
 
     %br
 
     %label= l(:label_https_access) + ' :'
-    = raw "https://<em>redmine-user</em>@#{https_server_domain}/#{http_server_subdir}<em>#{hierarchical_organisation ? 'project1/project2/' : ''}project3.git</em>"
+    = raw "https://<em>redmine-user</em>@#{https_server_domain}/#{http_server_subdir}<em>#{sample_def}</em>"
 
   %p
     %label= l(:label_example_repository)
     %br
 
     %label= l(:label_storage_directory) + ' :'
-    = raw "~#{gitolite_user}/#{gitolite_global_storage_dir}#{gitolite_redmine_storage_dir}<em>#{hierarchical_organisation ? 'project1/project2/project3/' : ''}example.git</em>"
+    = raw "~#{gitolite_user}/#{gitolite_global_storage_dir}#{gitolite_redmine_storage_dir}<em>#{sample_eg}</em>"
 
     %br
 
     %label= l(:label_ssh_access) + ' :'
     - gitSHP = ssh_server_domain.match(/:\d+$/)
-    = raw "#{gitSHP ? 'ssh://' : ''}#{gitolite_user}@#{ssh_server_domain}#{gitSHP ? '/' : ':'}#{gitolite_redmine_storage_dir}<em>#{hierarchical_organisation ? 'project1/project2/project3/' : ''}example.git</em>"
+    = raw "#{gitSHP ? 'ssh://' : ''}#{gitolite_user}@#{ssh_server_domain}#{gitSHP ? '/' : ':'}#{gitolite_redmine_storage_dir}<em>#{sample_eg}</em>"
 
     %br
 
     %label= l(:label_http_access) + ' :'
-    = raw "http://<em>redmine-user</em>@#{http_server_domain}/#{http_server_subdir}<em>#{hierarchical_organisation ? 'project1/project2/project3/' : ''}example.git</em>"
+    = raw "http://<em>redmine-user</em>@#{http_server_domain}/#{http_server_subdir}<em>#{sample_eg}</em>"
 
     %br
 
     %label= l(:label_https_access) + ' :'
-    = raw "https://<em>redmine-user</em>@#{https_server_domain}/#{http_server_subdir}<em>#{hierarchical_organisation ? 'project1/project2/project3/' : ''}example.git</em>"
+    = raw "https://<em>redmine-user</em>@#{https_server_domain}/#{http_server_subdir}<em>#{sample_eg}</em>"
 
     %br
     %br
@@ -73,3 +83,7 @@
 
   = raw l(:display_access_emphasis)
   = raw hierarchical_organisation ? l(:display_access_hierarchical) : l(:display_access_flat)
+
+  %br
+
+  = raw  gitolite_one_level_repo_depth ? l(:display_access_gitolite_one_level) : ''

--- a/app/views/settings/redmine_git_hosting/_redmine_config.html.haml
+++ b/app/views/settings/redmine_git_hosting/_redmine_config.html.haml
@@ -4,6 +4,7 @@
 - init_repositories_on_create        = RedmineGitHosting::Config.get_setting(:init_repositories_on_create, true)
 - delete_git_repositories            = RedmineGitHosting::Config.get_setting(:delete_git_repositories, true)
 - hierarchical_organisation          = RedmineGitHosting::Config.get_setting(:hierarchical_organisation, true)
+- gitolite_one_level_repo_depth      = RedmineGitHosting::Config.get_setting(:gitolite_one_level_repo_depth, true)
 
 %h3= l(:label_redmine_config)
 
@@ -30,6 +31,15 @@
   = bootstrap_switch_tag do
     = hidden_field_tag 'settings[delete_git_repositories]', 'false'
     = check_box_tag 'settings[delete_git_repositories]', delete_git_repositories, delete_git_repositories
+
+
+%p
+  %label= l(:label_gitolite_one_level_repo_depth)
+  = bootstrap_switch_tag do
+    = hidden_field_tag 'settings[gitolite_one_level_repo_depth]', 'false'
+    = check_box_tag 'settings[gitolite_one_level_repo_depth]', gitolite_one_level_repo_depth, gitolite_one_level_repo_depth, {:disabled => !hierarchical_organisation}
+
+%br
 
 %p
   %label= l(:label_hierarchical_organisation)

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -120,6 +120,7 @@ en:
   label_all_projects_use_git: Automatically initialize Git repositories for new projects?
   label_delete_git_repositories: Delete Git repository when project deleted?<br/>(will be place in recycle bin)
   label_init_repositories_on_create: Automatically initialize Git repositories with a README file (à la Github)
+  label_gitolite_one_level_repo_depth: Restrict repos URI to max depth of one level. (project/repo.git)
   label_hierarchical_organisation: Directory and URL structure for Redmine-managed repositories
   label_unique_repo_identifier: Repository identifiers are globally unique?
 
@@ -136,6 +137,7 @@ en:
   display_access_emphasis: "In the above patterns, <em>emphasized</em> components represent context-dependent elements."
   display_access_hierarchical: "Parent projects are included in the URLs, since the repository is in <em>Hierarchical</em> mode."
   display_access_flat: "Parent projects are not included in the URLs, since the repository is in <em>Flat</em> mode."
+  display_access_gitolite_one_level: "Hierarchical mode is accessed only through <em>one level depth</em>."
 
   label_flat: Flat
   label_hierarchical: Hierarchical

--- a/lib/default_settings.yml
+++ b/lib/default_settings.yml
@@ -55,6 +55,7 @@ delete_git_repositories:            'true'
 # When hierarchical_organisation = false unique_repo_identifier MUST be true
 hierarchical_organisation:        'true'
 unique_repo_identifier:           'false'
+gitolite_one_level_repo_depth:    'false'
 
 # Download Revision Config
 download_revision_enabled:        'true'

--- a/lib/redmine_git_hosting/config/redmine_config.rb
+++ b/lib/redmine_git_hosting/config/redmine_config.rb
@@ -40,6 +40,11 @@ module RedmineGitHosting
       end
 
 
+      def gitolite_one_level_repo_depth?
+        get_setting(:gitolite_one_level_repo_depth, true)
+      end
+
+
       def show_repositories_url?
         get_setting(:show_repositories_url, true)
       end


### PR DESCRIPTION
…ion.

Brief:
With previous hierarchical style, if there is repo created within nested
projects, or better described as "subprojcts of subprojects", for user to
access it he needs to specify full blown URL to reach repos.

E.g repository: foo.git
http://redmine/projects1/project2/project3/project4/project5/foo.git

This patch implements same hierarchical style but with access to it
by only using <project_identifier>/repo.git

E.g
http://redmine/project5/foo.git