### PR TITLE
fix option name

### DIFF
--- a/lib/redmine_git_hosting/gitolite_wrapper.rb
+++ b/lib/redmine_git_hosting/gitolite_wrapper.rb
@@ -89,6 +89,7 @@ module RedmineGitHosting
         {
           git_user:     RedmineGitHosting::Config.gitolite_user,
           hostname:     "#{RedmineGitHosting::Config.gitolite_server_host}:#{RedmineGitHosting::Config.gitolite_server_port}",
+          host:     "#{RedmineGitHosting::Config.gitolite_server_host}:#{RedmineGitHosting::Config.gitolite_server_port}",
           author_name:  RedmineGitHosting::Config.git_config_username,
           author_email: RedmineGitHosting::Config.git_config_email,
           public_key:   RedmineGitHosting::Config.gitolite_ssh_public_key,


### PR DESCRIPTION
Today i was found that gitolite config is not updated when changing options in Redmine.

I was found error in logs:
```
2019-07-04 15:51:21 +0300 [ERROR] Access denied for Gitolite Admin SSH Keys
2019-07-04 15:51:21 +0300 [ERROR] malformed URL 'ssh://git@/gitolite-admin.git'
```
After quick review i was fixed it. Last version of gitolite-rugged uses option "host" instead of "hostname", so i was added duplicated option for compatability.

Sorry if something wrong, i was never written on Ruby before. After this fix everything works fine.