### PR TITLE
Fix #715 by correcting misuse of ActiveRecord API for GitCache objects

### DIFF
--- a/lib/redmine_git_hosting/cache/database.rb
+++ b/lib/redmine_git_hosting/cache/database.rb
@@ -47,7 +47,7 @@ module RedmineGitHosting
         end
 
         def apply_cache_limit
-          GitCache.find(:last, order: 'created_at DESC').destroy if max_cache_elements >= 0 && GitCache.count > max_cache_elements
+          GitCache.order(:created_at).first.destroy if max_cache_elements >= 0 && GitCache.count > max_cache_elements
         end
       end
     end


### PR DESCRIPTION
This caused frequent 404 errors on the "Repository" view whenever
GitCache needed to be purged.

The initial bug (as described in #715) was reproduced and corrected for the most recent versions (to date) of Redmine and redmine_git_hosting plugins:
- Redmine 4.1.0
- redmine_git_hosting 4.0.1
- Git cache adapter set to "Database"