### PR TITLE
Add  ssh port to repository access url

### DIFF
--- a/app/models/concerns/gitolitable/urls.rb
+++ b/app/models/concerns/gitolitable/urls.rb
@@ -23,7 +23,7 @@ module Gitolitable
 
 
     def ssh_url
-      "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}/#{git_access_path}"
+      "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}:#{RedmineGitHosting::Config.gitolite_server_port}/#{git_access_path}"
     end
 
 

--- a/app/models/concerns/gitolitable/urls.rb
+++ b/app/models/concerns/gitolitable/urls.rb
@@ -23,7 +23,11 @@ module Gitolitable
 
 
     def ssh_url
-      "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}:#{RedmineGitHosting::Config.gitolite_server_port}/#{git_access_path}"
+      if RedmineGitHosting::Config.gitolite_server_port == '22'
+        "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}/#{git_access_path}"
+      else
+        "ssh://#{RedmineGitHosting::Config.gitolite_user}@#{RedmineGitHosting::Config.ssh_server_domain}:#{RedmineGitHosting::Config.gitolite_server_port}/#{git_access_path}"
+      end
     end
 
 


### PR DESCRIPTION
This change is to solve  #767 

If the ssh port is not changed, the ssh url will have a redundant :22 port number . I'm not an expert in ruby and not able to add a condition to handle this case. 

UPD: added a condition to skip the default port 