### PR TITLE
Update ci_tools.rake

### DIFF
--- a/lib/tasks/ci_tools.rake
+++ b/lib/tasks/ci_tools.rake
@@ -2,7 +2,7 @@
 
 namespace :redmine_git_hosting do
   namespace :ci do
-    unless Rails.env.production?
+    if Rails.env.development? || Rails.env.test?
       RSpec::Core::RakeTask.new do |task|
         task.rspec_opts = '--pattern plugins/redmine_git_hosting/spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color'
       end


### PR DESCRIPTION
A solution for #749.

In *Gemfile* is defined:
```ruby
group :development, :test do
  gem 'rspec'
  ...
```
and then in the code:
```ruby
unless Rails.env.production?
   RSpec::Core::RakeTask.new do |task|
    ...
```
So if RAILS_ENV is not specified, RSpec is not defined.