### PR TITLE
Update watchers_helper_patch.rb

### DIFF
--- a/lib/redmine_git_hosting/patches/watchers_helper_patch.rb
+++ b/lib/redmine_git_hosting/patches/watchers_helper_patch.rb
@@ -24,7 +24,7 @@ module RedmineGitHosting
       def watchers_list_with_git_hosting(object)
         remove_allowed = User.current.allowed_to? "delete_#{object.class.name.underscore}_watchers".tr('/', '_').to_sym, object.project
         content = +''.html_safe
-        object.watcher_users.preload(:email_address).each do |user|
+        object.watcher_users.each do |user|
           s = +''.html_safe
           s << avatar(user, size: '16').to_s
           s << link_to_user(user, class: 'user')


### PR DESCRIPTION
If a group is among issue's watchers, calling `preload(:email_address)` causes Error 500 as there is no `email_address` in Group class.