### PR TITLE
console logger: Fix undefined variable or method block

### DIFF
--- a/lib/redmine_git_hosting/console_logger.rb
+++ b/lib/redmine_git_hosting/console_logger.rb
@@ -6,7 +6,7 @@ module RedmineGitHosting
 
     def title(message)
       info "\n * #{message}:"
-      yield if block
+      yield if block_given?
       info " Done!\n\n"
     end
 


### PR DESCRIPTION
Fixes #805 .

replace `yield if block` which is incorrect at least nowadays by `yield if block_given?`.

```
REDMINE_INSTANCE=default bundle exec rake redmine_git_hosting:install_hook_files                         
                                                    
 * Installing/updating Gitolite hooks:
rake aborted!                                       
NameError: undefined local variable or method `block' for RedmineGitHosting::ConsoleLogger:Module
/usr/share/redmine/plugins/redmine_git_hosting/lib/redmine_git_hosting/console_logger.rb:9:in `title'    
/usr/share/redmine/plugins/redmine_git_hosting/lib/tasks/redmine_git_hosting.rake:71:in `block (2 levels) in <top (required)>'                                                                                     
/usr/share/rubygems-integration/all/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'                   
Tasks: TOP => redmine_git_hosting:install_hook_files                                                     
(See full trace by running task with --trace)
```