### PR TITLE
Fix ruby3

### DIFF
--- a/contrib/hooks/post-receive/lib/git_hosting_http_helper.rb
+++ b/contrib/hooks/post-receive/lib/git_hosting_http_helper.rb
@@ -8,7 +8,7 @@ require 'uri'
 module GitHosting
   module HttpHelper
     def http_post(url, opts = {}, &block)
-      http, request = build_post_request url, opts
+      http, request = build_post_request url, **opts
       send_http_request http, request, &block
     end
 

--- a/lib/redmine/scm/adapters/xitolite_adapter.rb
+++ b/lib/redmine/scm/adapters/xitolite_adapter.rb
@@ -187,7 +187,7 @@ module Redmine
           nil
         end
 
-        def revisions(path, identifier_from, identifier_to, **options)
+        def revisions(path, identifier_from, identifier_to, options={})
           revs = Revisions.new
           cmd_args = %w[log --no-color --encoding=UTF-8 --raw --date=iso --pretty=fuller --parents --stdin]
           cmd_args << '--no-renames' if self.class.client_version_above? [2, 9]

--- a/lib/redmine_git_hosting/gitolite_handlers/repositories/add_repository.rb
+++ b/lib/redmine_git_hosting/gitolite_handlers/repositories/add_repository.rb
@@ -30,8 +30,8 @@ module RedmineGitHosting
 
         attr_reader :force
 
-        def initialize(*args)
-          super
+        def initialize(gitolite_config, repository, context, **options)
+          super(gitolite_config, repository, context, **options)
           @force     = options.delete(:force) { false }
           @old_perms = options.delete(:old_perms) { {} }
         end

--- a/lib/redmine_git_hosting/gitolite_wrappers/base.rb
+++ b/lib/redmine_git_hosting/gitolite_wrappers/base.rb
@@ -49,19 +49,19 @@ module RedmineGitHosting
       end
 
       def create_gitolite_repository(repository)
-        GitoliteHandlers::Repositories::AddRepository.call gitolite_config, repository, context, options
+        GitoliteHandlers::Repositories::AddRepository.call gitolite_config, repository, context, **options
       end
 
       def update_gitolite_repository(repository)
-        GitoliteHandlers::Repositories::UpdateRepository.call gitolite_config, repository, context, options
+        GitoliteHandlers::Repositories::UpdateRepository.call gitolite_config, repository, context, **options
       end
 
       def delete_gitolite_repository(repository)
-        GitoliteHandlers::Repositories::DeleteRepository.call gitolite_config, repository, context, options
+        GitoliteHandlers::Repositories::DeleteRepository.call gitolite_config, repository, context, **options
       end
 
       def move_gitolite_repository(repository)
-        GitoliteHandlers::Repositories::MoveRepository.call gitolite_config, repository, context, options
+        GitoliteHandlers::Repositories::MoveRepository.call gitolite_config, repository, context, **options
       end
 
       def create_gitolite_key(key)

--- a/lib/redmine_git_hosting/gitolite_wrappers/repositories/add_repository.rb
+++ b/lib/redmine_git_hosting/gitolite_wrappers/repositories/add_repository.rb
@@ -35,7 +35,7 @@ module RedmineGitHosting
           logger.info 'Execute Gitolite Plugins'
 
           # Create README file or initialize GitAnnex
-          RedmineGitHosting::Plugins.execute :post_create, repository, options.merge(recovered: @recovered)
+          RedmineGitHosting::Plugins.execute :post_create, repository, **options.merge(recovered: @recovered)
 
           # Fetch changeset
           repository.fetch_changesets

--- a/lib/redmine_git_hosting/gitolite_wrappers/repositories/update_repository.rb
+++ b/lib/redmine_git_hosting/gitolite_wrappers/repositories/update_repository.rb
@@ -26,7 +26,7 @@ module RedmineGitHosting
           logger.info 'Execute Gitolite Plugins'
 
           # Delete Git Config Keys
-          RedmineGitHosting::Plugins.execute :post_update, repository, options
+          RedmineGitHosting::Plugins.execute :post_update, repository, **options
 
           # Fetch changeset
           repository.fetch_changesets

--- a/lib/redmine_git_hosting/plugins/extenders/branch_updater.rb
+++ b/lib/redmine_git_hosting/plugins/extenders/branch_updater.rb
@@ -4,8 +4,8 @@ module RedmineGitHosting::Plugins::Extenders
   class BranchUpdater < BaseExtender
     attr_reader :update_default_branch
 
-    def initialize(*args)
-      super
+    def initialize(repository, **options)
+      super(repository, **options)
       @update_default_branch = options.delete(:update_default_branch) { false }
     end
 

--- a/lib/redmine_git_hosting/plugins/extenders/config_key_deletor.rb
+++ b/lib/redmine_git_hosting/plugins/extenders/config_key_deletor.rb
@@ -4,8 +4,8 @@ module RedmineGitHosting::Plugins::Extenders
   class ConfigKeyDeletor < BaseExtender
     attr_reader :delete_git_config_key
 
-    def initialize(*args)
-      super
+    def initialize(repository, **options)
+      super(repository, **options)
       @delete_git_config_key = options.delete(:delete_git_config_key) { '' }
     end
 

--- a/lib/redmine_git_hosting/plugins/extenders/git_annex_creator.rb
+++ b/lib/redmine_git_hosting/plugins/extenders/git_annex_creator.rb
@@ -4,8 +4,8 @@ module RedmineGitHosting::Plugins::Extenders
   class GitAnnexCreator < BaseExtender
     attr_reader :enable_git_annex
 
-    def initialize(*args)
-      super
+    def initialize(repository, **options)
+      super(repository, **options)
       @enable_git_annex = options.delete(:enable_git_annex) { false }
     end
 

--- a/lib/redmine_git_hosting/plugins/extenders/readme_creator.rb
+++ b/lib/redmine_git_hosting/plugins/extenders/readme_creator.rb
@@ -6,8 +6,8 @@ module RedmineGitHosting::Plugins::Extenders
   class ReadmeCreator < BaseExtender
     attr_reader :create_readme_file
 
-    def initialize(*args)
-      super
+    def initialize(repository, **options)
+      super(repository, **options)
       @create_readme_file = options.delete(:create_readme_file) { false }
     end
 


### PR DESCRIPTION
Moslty cope with automatic hash to keyword arguments and keyword arguments to hash deprecation by adding double sprat to the callers as was already done on this repository. Plus cope with keyword arguments delegation.

Plus replace a hash to keywords argument by a positional optional hahs argument.

Though this is fine I believe we never intended to make use of a hash to keyword arguments idiom. The use case is only a positional optional hash which is better done with a parameter as `, options = {}` than `, **options`.
But this will require to switch more code than is done in this patch. Maybe a task for later.
I did replace the double sprat by a positional optional hash parameter once in this patchset but this was because it was a specialization of a redmine signature that was already using the `, options = {}` and thus the double sprat was breaking when called by the redmine code.