### PR TITLE
Fix uninitialized constant #<Class:RedmineGitHosting::Cache::AbstractCache>::Timezone

### DIFF
--- a/lib/redmine_git_hosting/cache/abstract_cache.rb
+++ b/lib/redmine_git_hosting/cache/abstract_cache.rb
@@ -56,7 +56,7 @@ module RedmineGitHosting
         def valid_cache_entry?(cached_entry_date)
           return true if max_cache_time.to_i.negative? # No expiration needed
 
-          current_time = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Timezone.now
+          current_time = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.zone.now
           expired = current_time.to_i - cached_entry_date.to_i > max_cache_time
           !expired
         end


### PR DESCRIPTION
Typo Timezone.new instead of Time.zone.now

Closes #796 