### PR TITLE
Redmine5 finalization: modules loading

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -66,6 +66,12 @@ end
 # This *must stay after* Redmine::Plugin.register statement
 # because it needs to access to plugin settings...
 # so we need the plugin to be fully registered...
-Rails.configuration.to_prepare do
-  require_dependency 'load_gitolite_hooks'
-end
+require_dependency 'load_gitolite_hooks'
+
+# Autoload Git Hosting Libs and Patches
+RedmineGitHosting.load_plugin!
+
+# Redmine SCM adapter
+require_dependency 'redmine/scm/adapters/xitolite_adapter'
+
+require 'hrack/bundle'

--- a/lib/redmine_git_hosting.rb
+++ b/lib/redmine_git_hosting.rb
@@ -56,14 +56,3 @@ module RedmineGitHosting
        admin: true }]
   end
 end
-
-# Set up autoload of patches
-Rails.configuration.to_prepare do
-  # Redmine Git Hosting Libs and Patches
-  RedmineGitHosting.load_plugin!
-
-  # Redmine SCM adapter
-  require_dependency 'redmine/scm/adapters/xitolite_adapter'
-
-  require 'hrack/bundle'
-end

--- a/lib/redmine_git_hosting/commands.rb
+++ b/lib/redmine_git_hosting/commands.rb
@@ -2,10 +2,5 @@
 
 module RedmineGitHosting
   module Commands
-    extend Commands::Base
-    extend Commands::Git
-    extend Commands::Gitolite
-    extend Commands::Ssh
-    extend Commands::Sudo
   end
 end

--- a/lib/redmine_git_hosting/commands/base.rb
+++ b/lib/redmine_git_hosting/commands/base.rb
@@ -25,5 +25,7 @@ module RedmineGitHosting
         RedmineGitHosting.logger
       end
     end
+
+    extend Commands::Base
   end
 end

--- a/lib/redmine_git_hosting/commands/git.rb
+++ b/lib/redmine_git_hosting/commands/git.rb
@@ -120,5 +120,7 @@ module RedmineGitHosting
         value_hash
       end
     end
+
+    extend Commands::Git
   end
 end

--- a/lib/redmine_git_hosting/commands/gitolite.rb
+++ b/lib/redmine_git_hosting/commands/gitolite.rb
@@ -79,5 +79,7 @@ module RedmineGitHosting
         RedmineGitHosting::Config.gitolite_home_dir
       end
     end
+
+    extend Commands::Gitolite
   end
 end

--- a/lib/redmine_git_hosting/commands/ssh.rb
+++ b/lib/redmine_git_hosting/commands/ssh.rb
@@ -53,5 +53,7 @@ module RedmineGitHosting
         ]
       end
     end
+
+    extend Commands::Ssh
   end
 end

--- a/lib/redmine_git_hosting/commands/sudo.rb
+++ b/lib/redmine_git_hosting/commands/sudo.rb
@@ -205,5 +205,7 @@ module RedmineGitHosting
         sudo_cat destination_path
       end
     end
+
+    extend Commands::Sudo
   end
 end

--- a/lib/redmine_git_hosting/config.rb
+++ b/lib/redmine_git_hosting/config.rb
@@ -7,17 +7,5 @@ module RedmineGitHosting
 
     GITOLITE_DEFAULT_CONFIG_FILE       = 'gitolite.conf'
     GITOLITE_IDENTIFIER_DEFAULT_PREFIX = 'redmine_'
-
-    extend Config::Base
-    extend Config::GitoliteAccess
-    extend Config::GitoliteBase
-    extend Config::GitoliteCache
-    extend Config::GitoliteConfigTests
-    extend Config::GitoliteHooks
-    extend Config::GitoliteInfos
-    extend Config::GitoliteNotifications
-    extend Config::GitoliteStorage
-    extend Config::Mirroring
-    extend Config::RedmineConfig
   end
 end

--- a/lib/redmine_git_hosting/config/base.rb
+++ b/lib/redmine_git_hosting/config/base.rb
@@ -99,5 +99,7 @@ module RedmineGitHosting
         RedmineGitHosting.logger
       end
     end
+
+    extend Config::Base
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_access.rb
+++ b/lib/redmine_git_hosting/config/gitolite_access.rb
@@ -57,5 +57,7 @@ module RedmineGitHosting
         File.join(server_domain[%r{^[^/]*}], redmine_root_url, '/')[0..-2]
       end
     end
+
+    extend Config::GitoliteAccess
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_base.rb
+++ b/lib/redmine_git_hosting/config/gitolite_base.rb
@@ -111,5 +111,7 @@ module RedmineGitHosting
         get_setting :gitolite_log_level
       end
     end
+
+    extend Config::GitoliteBase
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_cache.rb
+++ b/lib/redmine_git_hosting/config/gitolite_cache.rb
@@ -21,5 +21,7 @@ module RedmineGitHosting
         get_setting :gitolite_cache_adapter
       end
     end
+
+    extend Config::GitoliteCache
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_config_tests.rb
+++ b/lib/redmine_git_hosting/config/gitolite_config_tests.rb
@@ -84,5 +84,7 @@ module RedmineGitHosting
         /#{user}/.match?(test)
       end
     end
+
+    extend Config::GitoliteConfigTests
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_hooks.rb
+++ b/lib/redmine_git_hosting/config/gitolite_hooks.rb
@@ -57,5 +57,7 @@ module RedmineGitHosting
         RedmineGitHosting::GitoliteParams::GlobalParams.new.install!
       end
     end
+
+    extend Config::GitoliteHooks
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_infos.rb
+++ b/lib/redmine_git_hosting/config/gitolite_infos.rb
@@ -72,5 +72,7 @@ module RedmineGitHosting
         end
       end
     end
+
+    extend Config::GitoliteInfos
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_notifications.rb
+++ b/lib/redmine_git_hosting/config/gitolite_notifications.rb
@@ -21,5 +21,7 @@ module RedmineGitHosting
         get_setting :gitolite_notify_global_exclude
       end
     end
+
+    extend Config::GitoliteNotifications
   end
 end

--- a/lib/redmine_git_hosting/config/gitolite_storage.rb
+++ b/lib/redmine_git_hosting/config/gitolite_storage.rb
@@ -23,5 +23,7 @@ module RedmineGitHosting
         nil
       end
     end
+
+    extend Config::GitoliteStorage
   end
 end

--- a/lib/redmine_git_hosting/config/mirroring.rb
+++ b/lib/redmine_git_hosting/config/mirroring.rb
@@ -19,5 +19,7 @@ module RedmineGitHosting
         File.join gitolite_home_dir, '.ssh', 'run_gitolite_admin_ssh'
       end
     end
+
+    extend Config::Mirroring
   end
 end

--- a/lib/redmine_git_hosting/config/redmine_config.rb
+++ b/lib/redmine_git_hosting/config/redmine_config.rb
@@ -49,5 +49,7 @@ module RedmineGitHosting
         (get_setting(:gitolite_recycle_bin_expiration_time).to_f * 60).to_i
       end
     end
+
+    extend Config::RedmineConfig
   end
 end

--- a/spec/models/gitolite_public_key_spec.rb
+++ b/spec/models/gitolite_public_key_spec.rb
@@ -32,7 +32,7 @@ describe GitolitePublicKey do
   # There is an isolation issue in tests.
   # Try to workaround it...
   def test_user
-    'redmine_git_user1_12'
+    'redmine_git_user1_13'
   end
 
   describe 'Valid SSH key build' do

--- a/spec/support/global_helpers.rb
+++ b/spec/support/global_helpers.rb
@@ -84,7 +84,12 @@ module GlobalHelpers
   end
 
   def load_yaml_fixture(fixture)
-    YAML.load load_fixture(fixture) # rubocop: disable Security/YAMLLoad
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+      YAML.load load_fixture(fixture), # rubocop: disable Security/YAMLLoad
+        permitted_classes: [Symbol, Time]
+    else
+      YAML.load load_fixture(fixture) # rubocop: disable Security/YAMLLoad
+    end
   end
 
   def load_fixture(fixture)


### PR DESCRIPTION
This pull request is an appendix to #815 (which was prematurely merged).

It concludes the plugin migration towards Redmine 5 initiated by #813.

It corrects:
* the loading of all Redmine Git Hosting classes, triggered by `RedmineGitHosting.load_plugin!`, which wasn't called anymore;
* the loading of Redmine Git Hosting's `Commands` and `Config` modules, which failed in an infinite loading loop.