### PR TITLE
Exclude body from span class float styling

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -144,7 +144,7 @@ STATISTICS
   width: 300px;
 }
 
-[class*="span"] {
+[class*="span"]:not(body) {
   float: left;
   margin-left: 20px;
   min-height: 1px;


### PR DESCRIPTION
Fix the page from looking like this
<img width="1358" height="710" alt="image" src="https://github.com/user-attachments/assets/df6ddc93-9c1a-44dd-a719-57c9bf0116d5" />

