### PR TITLE
Fix NoMethodError on cache expiry with Rails 7

### DIFF
--- a/lib/redmine_git_hosting/cache/abstract_cache.rb
+++ b/lib/redmine_git_hosting/cache/abstract_cache.rb
@@ -49,16 +49,23 @@ module RedmineGitHosting
         def time_limit
           return if max_cache_time.to_i.negative? # No expiration needed
 
-          current_time = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.zone.now
+          current_time = utc_default_timezone? ? Time.now.utc : Time.zone.now
           current_time - max_cache_time
         end
 
         def valid_cache_entry?(cached_entry_date)
           return true if max_cache_time.to_i.negative? # No expiration needed
 
-          current_time = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.zone.now
+          current_time = utc_default_timezone? ? Time.now.utc : Time.zone.now
           expired = current_time.to_i - cached_entry_date.to_i > max_cache_time
           !expired
+        end
+
+        def utc_default_timezone?
+          # +ActiveRecord::Base.default_timezone+ was removed in Rails 7 and
+          # replaced by +ActiveRecord.default_timezone+.
+          timezone = ActiveRecord.respond_to?(:default_timezone) ? ActiveRecord.default_timezone : ActiveRecord::Base.default_timezone
+          timezone == :utc
         end
       end
     end


### PR DESCRIPTION
Opening a repository on Redmine 6.1 / Rails 7.2 crashes with `NoMethodError (undefined method 'default_timezone' for class ActiveRecord::Base)` from `AbstractCache#valid_cache_entry?`. Rails 7 removed `ActiveRecord::Base.default_timezone` and moved it to `ActiveRecord.default_timezone`.

This routes both cache-time checks through a small `utc_default_timezone?` helper that reads `ActiveRecord.default_timezone` when available and falls back to the old accessor, so cache expiry keeps working on Rails 7+ as well as older Redmine versions the plugin still supports.

Fixes #847
